### PR TITLE
デプロイ手順と設定ファイルの中身を合わせました。nginxのconfがデフォルトになっているので修正しました。

### DIFF
--- a/cookbooks/skyhopper/files/default/nginx.conf
+++ b/cookbooks/skyhopper/files/default/nginx.conf
@@ -1,0 +1,27 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '\$remote_addr - \$remote_user [\$time_local] "\$request" '
+                      '\$status \$body_bytes_sent "\$http_referer" '
+                      '"\$http_user_agent" "\$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/cookbooks/skyhopper/recipes/default.rb
+++ b/cookbooks/skyhopper/recipes/default.rb
@@ -71,6 +71,14 @@ package 'nginx' do
   notifies :enable, 'service[nginx]'
 end
 
+cookbook_file "/etc/nginx/nginx.conf" do
+  source "nginx.conf"
+  mode 0644
+  owner 'root'
+  group 'root'
+  notifies :reload, 'service[nginx]'
+end
+
 template 'nginx skyhopper.conf' do
   source 'nginx_skyhopper.conf.erb'
   path "/etc/nginx/conf.d/skyhopper.conf"

--- a/cookbooks/skyhopper/templates/default/nginx_skyhopper.conf.erb
+++ b/cookbooks/skyhopper/templates/default/nginx_skyhopper.conf.erb
@@ -1,22 +1,30 @@
 server {
+        client_max_body_size 1g;
+
         listen 80;
-        server_name <%= node['skyhopper']['server_name'] %>;
+        server_name _;
 
         location ~ ^/(assets|fonts) {
-          root <%= node['skyhopper']['root_dir'] %>/public;
+            root <%= node['skyhopper']['root_dir'] %>/public;
         }
 
         location / {
-            proxy_set_header    X-Real-IP   $remote_addr;
-            proxy_set_header    Host        $http_host;
-            proxy_pass          http://127.0.0.1:3000;
+            proxy_set_header    X-Real-IP   \$remote_addr;
+            proxy_set_header    Host   \$http_host;
+            proxy_pass  http://127.0.0.1:3000;
         }
 
         location /ws {
             proxy_http_version  1.1;
-            proxy_set_header    Upgrade    $http_upgrade;
+            proxy_set_header    Upgrade \$http_upgrade;
             proxy_set_header    Connection "upgrade";
-            proxy_set_header    Host       $http_host;
-            proxy_pass          http://127.0.0.1:3210;
+            proxy_set_header    Host   \$http_host;
+            proxy_pass  http://127.0.0.1:3210;
         }
+
+        location /502.html {
+            root <%= node['skyhopper']['root_dir'] %>/public;
+            try_files \$uri 502.html;
+        }
+        error_page 502 /502.html;
 }


### PR DESCRIPTION
* SkyHopperデプロイ手順とcookbookのテンプレートに差異があったので手順に合わせました。
* nginx.confがインストール後のデフォルトの状態となっていたため、修正しました。
* skyhopper.confのserver_nameを_(すべて)にしました。